### PR TITLE
Renamed the workflow templates

### DIFF
--- a/.github/workflows/pr-auto-semver.yml
+++ b/.github/workflows/pr-auto-semver.yml
@@ -1,0 +1,13 @@
+name: on-pr
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  pr-edit:
+    uses: geoadmin/.github/.github/workflows/pr-auto-semver.yml@master

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,11 @@
+name: on-push
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  release:
+    uses: geoadmin/.github/.github/workflows/semver-release.yml@master


### PR DESCRIPTION
The main workflow file parameter `name` is used in the github PR check
section as prefix to display every actions. In order to keep this display
a bit cleaner and short we use a shorter name.

e.g changed such display:

`PR New SemVer Release Auto Title / pr-edit / Set PR title (pull_request)`
`PR New SemVer Release Auto Title / pr-edit / Set PR label (pull_request)`

to

`on-pr / pr-edit / Set PR title (pull_request)`
`on-pr / pr-edit / Set PR label (pull_request)`